### PR TITLE
fix bug The second number has only one digit

### DIFF
--- a/02_calculator/main.cpp
+++ b/02_calculator/main.cpp
@@ -282,6 +282,7 @@ public:
     void pressNumber(int i) {
         if (m_needClearInput) {
             setLineText("0");
+            m_needClearInput = false;
         }
         QString text = m_line->text();
         text += QString::number(i);


### PR DESCRIPTION
操作符之后的数字只会留一位,m_needClearInput 始终是 true
```cpp
  void pressNumber(int i) {
      if (m_needClearInput) {
          setLineText("0");
      }
      QString text = m_line->text();
      text += QString::number(i);
      setLineText(text);
  }

  void pressOperator(Operator op) {
      double value = m_line->text().toDouble();
      m_lastValue = value;
      m_lastOperator = op;
      m_needClearInput = true;

      switch (op) {
      case Sqrt:
          pressEqual();
          break;
      default:
          break;
      };
  }
```